### PR TITLE
Reduce docker startup time to 190ms

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rust/cowsay"]
+	path = rust/cowsay
+	url = git@github.com:wapm-packages/cowsay.git

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,6 +1,9 @@
-FROM rustlang/rust:nightly
+FROM rustlang/rust:nightly as build
 COPY cowsay /usr/src/myapp/
 WORKDIR /usr/src/myapp
 
 RUN cargo build --release
-CMD [ "./target/release/cowsay", "\"Hello World\"" ]
+
+FROM scratch
+COPY --from=build /usr/src/myapp/target/release/cowsay /cowsay
+CMD [ "/cowsay", "\"Hello World\"" ]

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -9,11 +9,15 @@ docker:
 	# Get the size of the container
 	docker images | grep my-rust-app
 
+	docker create --net=host --pid=host --name my-running-app-1 my-rust-app
 	# Time it!
-	time docker run -it --rm --name my-running-app my-rust-app
+	time docker start my-running-app-1
+	docker rm -f my-running-app-1
 
+	docker create --net=host --pid=host --name my-running-app-2 my-rust-app
 	# Analyze memory usage
-	../memusg.sh docker run -it --rm --name my-running-app my-rust-app
+	../memusg.sh docker start my-running-app-2
+	docker rm -f my-running-app-2
 
 # Alpine not supported here because of musl dependency issues on the Rust Crate
 

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -1,7 +1,7 @@
 docker:
 	# Docker container size: 1.72GB
-	# Running time: ~614ms
-	# Memory peak: 22960
+	# Running time: ~190ms
+	# Memory peak: 24676
 
 	# Prepare the container
 	docker build -t my-rust-app .

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -9,15 +9,15 @@ docker:
 	# Get the size of the container
 	docker images | grep my-rust-app
 
-	docker create --net=host --pid=host --name my-running-app-1 my-rust-app
+	@ docker create --net=host --pid=host --name my-running-app-1 my-rust-app >/dev/null
 	# Time it!
 	time docker start my-running-app-1
-	docker rm -f my-running-app-1
+	@ docker rm -f my-running-app-1 >/dev/null
 
-	docker create --net=host --pid=host --name my-running-app-2 my-rust-app
+	@ docker create --net=host --pid=host --name my-running-app-2 my-rust-app >/dev/null
 	# Analyze memory usage
 	../memusg.sh docker start my-running-app-2
-	docker rm -f my-running-app-2
+	@ docker rm -f my-running-app-2 >/dev/null
 
 # Alpine not supported here because of musl dependency issues on the Rust Crate
 


### PR DESCRIPTION
Hi and thanks for your work! :)

I've tweaked your benchmark a little, only the Docker part:
- Separated `run` into `create` and `start`
- Used `--net=host` and `--pid=host` to avoid namespace creation overhead
- Removed `-it` and `--rm` to reduce startup time & memory further
- Used `scratch` for running the final `cowsay` binary

I also added `.gitmodules`, so others can checkout `cowsay`.

Now I get the following results:
```
# Time it!
time docker start my-running-app-1
my-running-app-1
        0.19 real         0.02 user         0.01 sys

# Analyze memory usage
../memusg.sh docker start my-running-app-2
my-running-app-2
memusg: peak=24296
```

P.S. I noticed that startup time vary sometimes to `0.20`, and sometimes even to `5.26`. In these cases, I had to restart Docker Daemon
P.P.S. I'm running benchmarks on MacOS, not sure if Linux would be more or less performant.